### PR TITLE
Actions updated for Go builds and dist zip

### DIFF
--- a/.github/workflows/cavi-go-builds.yml
+++ b/.github/workflows/cavi-go-builds.yml
@@ -1,12 +1,12 @@
 name: CAVI Go Builds
 
 on:
-  # push:
-  #   paths:
-  #     - "rtsutils/go/**"
-  #   branches:
-  #     - develop
-  #     - stable
+  push:
+    paths:
+      - "rtsutils/go/cavi/**"
+    branches:
+      # - develop
+      - stable
   workflow_dispatch:
 jobs:
   windows-build:
@@ -80,7 +80,7 @@ jobs:
           path: ${{ github.workspace }}/rtsutils/go/linux/
 
   update-repo:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     needs: [ubuntu-build, macos-build, windows-build]
     steps:
       - name: Checkout Repo
@@ -103,6 +103,12 @@ jobs:
         with:
           name: dist-ubuntu
           path: ${{ github.workspace }}/rtsutils/go/linux/
+
+      - name: Zip Source
+        shell: pwsh
+        run: |
+          Compress-Archive -Path ${{ github.workspace }}\rtsutils `
+          -DestinationPath ${{ github.workspace }}\dist\${{ github.event.repository.name }}.zip -Force
 
       - name: Commit Changes
         uses: EndBug/add-and-commit@v8

--- a/.github/workflows/distribution-zip.yml
+++ b/.github/workflows/distribution-zip.yml
@@ -1,6 +1,13 @@
 name: Distribution Zip Files
 
 on:
+  push:
+    paths:
+      - "rtsutils/**"
+      - "!rtsutils/go/cavi/**"
+    branches:
+      # - develop
+      - stable
   workflow_dispatch:
 jobs:
   windows-zip:


### PR DESCRIPTION
The `stable` branch is active in actions to build the Go and zip file for distribution.  Branch `develop` currently commented out until refactoring branches is complete.